### PR TITLE
Fix: Add container info. when viewing logs

### DIFF
--- a/docs/otel/k3s.md
+++ b/docs/otel/k3s.md
@@ -107,7 +107,7 @@ Use the label set by the `helm` install to tail logs (You will need to press ++c
 === "Shell Command"
 
     ```
-    kubectl logs -l app=splunk-otel-collector -f
+    kubectl logs -l app=splunk-otel-collector -f --container otel-collector
     ```
 
 === "Example Output"


### PR DESCRIPTION
Missing container info.