### PR TITLE
Update instruction to recommend using Firefox

### DIFF
--- a/docs/eks/readme-b.md
+++ b/docs/eks/readme-b.md
@@ -1,5 +1,6 @@
 # Steps to access EKS cluster
 ## Login into AWS console from the Event Engine dashboard
+You are encouraged to use the Firefox web browser. It is because pasting from clipboard into the required web terminal may not work in later steps.
 ![Event Engine](../images/eks/credentials.png)
 
 Remeber to only use "us-west-2" as your region


### PR DESCRIPTION
Drawing from our workshop experience today (13 Oct), participants feedback that copy and paste did not work on Chrome. It worked on Firefox. It is useful to copy and paste during the workshop.